### PR TITLE
[25.02.23] 전표 추가 및 저장 구현

### DIFF
--- a/cafe-sync/src/apis/slip/slipApi.js
+++ b/cafe-sync/src/apis/slip/slipApi.js
@@ -1,3 +1,4 @@
+// 가맹점별 전표 데이터 조회
 export async function getFranSlipList(franCode, startDate, endDate) {
   if (!franCode || !startDate || !endDate) {
     console.error("❌ 필요한 데이터가 없습니다!");
@@ -61,5 +62,258 @@ export async function getFranSlipList(franCode, startDate, endDate) {
   } catch (error) {
     console.error("❌ 전표 데이터를 가져오는 중 오류 발생:", error);
     return [];
+  }
+}
+
+// 거래처 정보 조회
+export async function getVendorList() {
+  try {
+    let token = sessionStorage.getItem("accessToken");
+    const refreshToken = sessionStorage.getItem("refreshToken");
+    // 실제 API 엔드포인트에 맞게 수정
+    const apiUrl = `http://localhost:8080/api/fran/vendor`;
+
+    let response = await fetch(apiUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    // 403이면 Access Token 만료 처리
+    if (response.status === 403 && refreshToken) {
+      console.warn("🔄 Access Token 만료됨. Refresh Token으로 갱신 시도...");
+      const refreshResponse = await fetch(
+        "http://localhost:8080/api/refresh-token",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ refreshToken }),
+        }
+      );
+
+      if (!refreshResponse.ok) {
+        throw new Error("❌ Refresh Token 갱신 실패! 다시 로그인해야 합니다.");
+      }
+
+      const newTokenData = await refreshResponse.json();
+      token = newTokenData.accessToken;
+      sessionStorage.setItem("accessToken", token);
+
+      // 새 Access Token으로 다시 요청
+      response = await fetch(apiUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP 오류! 상태 코드: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("✅ 거래처 데이터 조회 성공:", data);
+    return data;
+  } catch (error) {
+    console.error("❌ 거래처 데이터를 가져오는 중 오류 발생:", error);
+    return [];
+  }
+}
+
+// 계정과목 조회
+export async function getAccountList() {
+  try {
+    let token = sessionStorage.getItem("accessToken");
+    const refreshToken = sessionStorage.getItem("refreshToken");
+
+    // 실제 API 엔드포인트(계정과목 조회용)으로 변경
+    const apiUrl = "http://localhost:8080/api/fran/act";
+
+    let response = await fetch(apiUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    // 🔹 403 (Forbidden)이면 Access Token 만료 → Refresh Token으로 갱신
+    if (response.status === 403 && refreshToken) {
+      console.warn("🔄 Access Token 만료됨. Refresh Token으로 갱신 시도...");
+
+      const refreshResponse = await fetch(
+        "http://localhost:8080/api/refresh-token",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ refreshToken }),
+        }
+      );
+
+      if (!refreshResponse.ok) {
+        throw new Error("❌ Refresh Token 갱신 실패! 다시 로그인해야 합니다.");
+      }
+
+      const newTokenData = await refreshResponse.json();
+      token = newTokenData.accessToken;
+      sessionStorage.setItem("accessToken", token);
+
+      // 새 Access Token으로 다시 요청
+      response = await fetch(apiUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP 오류! 상태 코드: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("✅ 계정과목 데이터 조회 성공:", data);
+    return data; // ← 배열(또는 객체) 형태라고 가정
+  } catch (error) {
+    console.error("❌ 계정과목 데이터를 가져오는 중 오류 발생:", error);
+    return []; // 오류 시 빈 배열 반환
+  }
+}
+
+// 적요 조회
+export async function getSummaryList() {
+  try {
+    let token = sessionStorage.getItem("accessToken");
+    const refreshToken = sessionStorage.getItem("refreshToken");
+
+    // 실제 API 엔드포인트(적요 조회용)으로 변경
+    const apiUrl = "http://localhost:8080/api/fran/summary";
+
+    let response = await fetch(apiUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    // 🔹 403 (Forbidden)이면 Access Token 만료 → Refresh Token으로 갱신
+    if (response.status === 403 && refreshToken) {
+      console.warn("🔄 Access Token 만료됨. Refresh Token으로 갱신 시도...");
+
+      const refreshResponse = await fetch(
+        "http://localhost:8080/api/refresh-token",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ refreshToken }),
+        }
+      );
+
+      if (!refreshResponse.ok) {
+        throw new Error("❌ Refresh Token 갱신 실패! 다시 로그인해야 합니다.");
+      }
+
+      const newTokenData = await refreshResponse.json();
+      token = newTokenData.accessToken;
+      sessionStorage.setItem("accessToken", token);
+
+      // 새 Access Token으로 다시 요청
+      response = await fetch(apiUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP 오류! 상태 코드: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("✅ 적요 데이터 조회 성공:", data);
+    return data; // ← 서버에서 { data: [...]} 형태면 data.data 를 반환해야 할 수도 있음
+  } catch (error) {
+    console.error("❌ 적요 데이터를 가져오는 중 오류 발생:", error);
+    return []; // 오류 시 빈 배열 반환
+  }
+}
+
+// 전표(체크된 행) 일괄 저장(Insert/Update)
+export async function saveSlipList(slipArray) {
+  try {
+    let token = sessionStorage.getItem("accessToken");
+    const refreshToken = sessionStorage.getItem("refreshToken");
+
+    // 실제 API 엔드포인트 (예: POST /api/fran/slip)
+    const apiUrl = "http://localhost:8080/api/fran/slip";
+
+    // slipArray: [ { slipCode, slipDate, venCode, slipDivision, ... }, ... ]
+    let response = await fetch(apiUrl, {
+      method: "POST", // POST나 PUT 등 서버 규칙에 맞게
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(slipArray), // 배열 형태로 전송
+    });
+
+    // 403이면 토큰 만료 처리
+    if (response.status === 403 && refreshToken) {
+      console.warn("🔄 Access Token 만료됨. Refresh Token으로 갱신 시도...");
+
+      const refreshResponse = await fetch(
+        "http://localhost:8080/api/refresh-token",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ refreshToken }),
+        }
+      );
+
+      if (!refreshResponse.ok) {
+        throw new Error("❌ Refresh Token 갱신 실패! 다시 로그인해야 합니다.");
+      }
+
+      const newTokenData = await refreshResponse.json();
+      token = newTokenData.accessToken;
+      sessionStorage.setItem("accessToken", token);
+
+      // 새 토큰으로 다시 요청
+      response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(slipArray),
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP 오류! 상태 코드: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("✅ 전표 저장(Insert/Update) 성공:", data);
+    return data;
+  } catch (error) {
+    console.error("❌ 전표 저장 중 오류 발생:", error);
+    return null;
   }
 }

--- a/cafe-sync/src/fran/pages/slip/Slip.module.css
+++ b/cafe-sync/src/fran/pages/slip/Slip.module.css
@@ -16,7 +16,6 @@
     font-size: 14px;
     font-weight: bold;
     border-radius: 5px;
-    
 }
 
 .dateInput {
@@ -147,6 +146,7 @@
     background-color: #E0A800;
 }
 
+/* 테이블 스타일 */
 .slipTable {
     width: 100%;
     border-collapse: collapse;
@@ -154,6 +154,13 @@
     border-radius: 5px;
     overflow: hidden;
     table-layout: fixed; /* 테이블 너비 고정 */
+}
+
+/* 체크박스 크기 통일 (헤더, 바디 모두) */
+.slipTable input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
 }
 
 .slipTable thead {
@@ -171,16 +178,64 @@
     text-overflow: ellipsis; /* 글자가 넘칠 경우 "..." 표시 */
 }
 
-/* 체크박스 컬럼 크기 유지 */
+/* 체크박스 컬럼(1번째) 고정 너비 */
 .slipTable th:first-child,
 .slipTable td:first-child {
-    width: 50px;
+    width: 60px;         /* 기존 50px → 60px으로 약간 넓힘 */
+    text-align: center;  /* 가운데 정렬 */
+    vertical-align: middle;
 }
 
-/* 나머지 컬럼 크기를 동일하게 */
-.slipTable th:not(:first-child),
-.slipTable td:not(:first-child) {
-    width: calc((100% - 50px) / 10); /* 체크박스 제외 10개 컬럼 동일한 너비 */
+
+/* 열별로 적당히 너비 설정 (2 ~ 11열) */
+.slipTable th:nth-child(2),
+.slipTable td:nth-child(2) {
+  width: 110px; /* 날짜 */
+}
+
+.slipTable th:nth-child(3),
+.slipTable td:nth-child(3) {
+  width: 100px; /* 거래처 코드 */
+}
+
+.slipTable th:nth-child(4),
+.slipTable td:nth-child(4) {
+  width: 120px; /* 거래처명 */
+}
+
+.slipTable th:nth-child(5),
+.slipTable td:nth-child(5) {
+  width: 80px; /* 구분 */
+}
+
+.slipTable th:nth-child(6),
+.slipTable td:nth-child(6) {
+  width: 110px; /* 계정과목 코드 */
+}
+
+.slipTable th:nth-child(7),
+.slipTable td:nth-child(7) {
+  width: 120px; /* 계정과목명 */
+}
+
+.slipTable th:nth-child(8),
+.slipTable td:nth-child(8) {
+  width: 110px; /* 적요 코드 */
+}
+
+.slipTable th:nth-child(9),
+.slipTable td:nth-child(9) {
+  width: 120px; /* 적요명 */
+}
+
+.slipTable th:nth-child(10),
+.slipTable td:nth-child(10) {
+  width: 90px; /* 차변(출금) */
+}
+
+.slipTable th:nth-child(11),
+.slipTable td:nth-child(11) {
+  width: 90px; /* 대변(입금) */
 }
 
 /* 짝수 행 배경색 변경 */
@@ -188,7 +243,28 @@
     background-color: #f9f9f9;
 }
 
-.noData{
+/* 셀 내부 인풋, 셀렉트 크기 조절 */
+.slipTable td input,
+.slipTable td select {
+    width: 90%;
+    max-width: 100%;
+    box-sizing: border-box;
+    height: 30px; /* 높이 맞춤 */
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    padding: 5px;
+    font-size: 14px;
+    text-align: center;
+    cursor: pointer;
+}
+
+.slipTable td select option {
+    text-align: center;
+}
+
+
+/* 데이터 없을 때 표시 영역 */
+.noData {
     width: 1780px;
     height: 640px;
     flex-direction: column;
@@ -202,3 +278,129 @@
     width: 100px;
     height: auto;
 }
+
+  
+  /* 모달 제목 */
+  .modalTitle {
+    margin: 0;
+    padding-bottom: 10px;
+    font-size: 18px;
+    font-weight: bold;
+    border-bottom: 1px solid #ccc;
+    text-align: left;   /* 제목 왼쪽 정렬 (원하시면 center로 바꿔도 됨) */
+  }
+  
+  /* 탭 + 검색 영역 컨테이너 */
+  /* 모달 상단: 탭 + 검색 영역을 감싸는 컨테이너 */
+.tabFilterContainer {
+  display: flex;
+  justify-content: space-between; /* 왼쪽 탭, 오른쪽 검색 */
+  align-items: center;           /* 수직 가운데 정렬 */
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+/* 탭 버튼 묶음 */
+.tabButtons {
+  display: flex;
+}
+
+/* 각 탭 버튼 */
+.tabButton {
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+  cursor: pointer;
+  font-size: 14px;
+}
+.tabButton:hover {
+  background-color: #e0e0e0;
+}
+.activeTab {
+  background-color: #007bff;
+  color: #fff;
+  border-color: #007bff;
+}
+
+/* 검색 박스 */
+.searchBox {
+  display: flex;
+  align-items: center;
+}
+
+/* 검색창 인풋 */
+.searchInput {
+  width: 140px;
+  height: 30px;
+  padding: 6px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  /* position, left 설정은 빼버리기! */
+}
+
+  
+  /* 테이블 */
+  .vendorTable {
+    width: 100%;       /* 모달 내부에서 꽉 차게 */
+    border-collapse: collapse;
+    margin-top: 10px;
+  }
+  
+  .vendorTable th,
+  .vendorTable td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: center;
+    font-size: 14px;
+  }
+  
+  .vendorTable thead {
+    background-color: #f1f1f1;
+  }
+  
+  .vendorTable tr:hover {
+    background-color: #f5f5f5;
+  }
+
+.modalWrapper {
+    position: fixed;
+    top: 50px;       /* 상단에서 50px 정도 띄움 */
+    left: 20px;      /* 왼쪽에서 20px */
+    right: auto;     /* 기본 center 해제 */
+    margin: 0;       /* 가운데 정렬 해제 */
+    transform: none; /* translate 해제 */
+  }
+  
+  .modalContainer {
+    width: 650px; 
+    padding: 20px;
+    box-sizing: border-box;
+    background-color: #fff; /* 원하는 배경 */
+    border-radius: 8px;
+  }
+  
+
+  /* 테이블 래퍼: 스크롤은 여기서 */
+.tableWrapper {
+    height: 470px;          /* 원하는 높이, 예: 300px */
+    overflow-y: auto;       /* 세로 스크롤 */
+    margin-top: 20px;
+  }
+
+  /* 테이블 */
+.vendorTable {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed; /* 열 너비 고정 분배 시 */
+  }
+
+  /* 테이블 헤더: sticky */
+.vendorTable thead th {
+    position: sticky; /* 스크롤 시 헤더 고정 */
+    top: 0;
+    background-color: #f1f1f1;
+    z-index: 2;       /* 헤더가 본문보다 위에 표시되도록 */
+  }
+
+  


### PR DESCRIPTION
## #️⃣ Issue Number

#125 #126 

## 📝 요약(Summary)

## 전표 추가 및 저장 기능이 구현 되었습니다
- 행 추가 버튼을 누를 시 테이블 행 하나가 추가 됩니다
- 거래처 코드, 계정과목 코드, 적요 코드 를 선택 시 모달창으로 각각의 데이터를 조회해온 후 선택 할 수 있습니다
- 구분 입금 및 출금 선택 시 차변과 대변은 입력할 수 없도록 하였고 차변 선택 시 대변 입력 불가, 대변 선택 시 차변 입력 불가 됩니다
- 하나의 전표 작성 시 필수 정보값을 없이 저장 버튼 누른다면 모든 필드값을 입력할 수 있도록 안내됩니다

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 행 추가
![image](https://github.com/user-attachments/assets/8b3c1916-a1ff-47ff-aecf-bb4cc5f4c02f)

## 거래처 모달
![image](https://github.com/user-attachments/assets/2dd18f93-a0ec-4676-bed6-85bbac9a5a34)

## 계정과목 모달
![image](https://github.com/user-attachments/assets/3ab4c10c-4c8f-4ecc-99bd-5cc6a3442349)

## 적요 모달
![image](https://github.com/user-attachments/assets/e747d8af-6563-4f30-9a3e-2016c5d85b01)

## 저장할 행을 선택하지 않을 시
![image](https://github.com/user-attachments/assets/c77dd9e7-fad3-4e0c-b939-064db5ce0cad)

## 모든 필드를 입력 안할 시 
![image](https://github.com/user-attachments/assets/82b949cf-e98b-4e06-b6c3-b39df3987f54)

## 저장 성공 시
![image](https://github.com/user-attachments/assets/56158ba8-769e-4ab3-885f-3c90db3bd406)


## ✅ PR Checklist

PR 에 대해 확인 하였으면 본인 이름을 체크해주세요. 
<br>
📢 마지막에 체크한 팀원이 merge 버튼을 눌러주세요.

- [x] 정근희
- [x] 윤이정
- [x] 김용욱
- [x] 정승찬
